### PR TITLE
Handling duplicates of migrations in database

### DIFF
--- a/ADatabaseMigrator/Core/MigratorBase.cs
+++ b/ADatabaseMigrator/Core/MigratorBase.cs
@@ -24,11 +24,11 @@ public abstract class MigratorBase<TMigration, TMigrationScript, TMigrationJourn
     protected IMigrationJournalManager<TMigrationJournal, TMigration, TMigrationScript> JournalManager { get; }
     protected IMigrationScriptRunner<TMigrationScript> ScriptRunner { get; }
 
-    public virtual async Task<IEnumerable<TMigrationScript>> Migrate(CancellationToken? cancellationToken = default)
+    public virtual async Task<IReadOnlyList<TMigrationScript>> Migrate(CancellationToken? cancellationToken = default)
     {
         var allMigrations = await ScriptLoader.Load(cancellationToken);
         var journal = await JournalManager.Load(cancellationToken);
-        var scriptsToRun = allMigrations.Where(x => ShouldRunScript(x, journal));
+        var scriptsToRun = allMigrations.Where(x => ShouldRunScript(x, journal)).ToList();
         await RunScripts(scriptsToRun, cancellationToken);
         return scriptsToRun;
     }

--- a/ADatabaseMigrator/Journaling/MigrationScriptJournalManager.cs
+++ b/ADatabaseMigrator/Journaling/MigrationScriptJournalManager.cs
@@ -29,6 +29,7 @@ public class MigrationScriptJournalManager(DbConnection _connection) : IMigratio
             """
             SELECT Version, Name, Applied, Hash, Type 
             FROM dbo.SchemaVersionJournal
+            ORDER BY Applied ASC
             """;
 
         using var reader = await command.ExecuteReaderAsync(cancellationToken ?? CancellationToken.None);


### PR DESCRIPTION
Handling the scenario of duplicates of a name exists in the database. This would be a normal case for `RunIfChanged` migrations.